### PR TITLE
remove dependency on ancient mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-mock
 pytest
 pika==0.13.0
 redis

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ config = {
         'Programming Language :: Python :: 3.4'
     ],
     'install_requires': requirements,
-    'tests_require': ['pytest', 'mock'],
+    'tests_require': ['pytest'],
     'packages': find_packages(),
     'include_package_data': True,
     'scripts': ['bin/biomaj_process_consumer.py'],

--- a/tests/biomaj_tests.py
+++ b/tests/biomaj_tests.py
@@ -6,8 +6,7 @@ import logging
 import copy
 import stat
 import time
-
-from mock import patch
+from unittest.mock import patch
 
 from biomaj_process.message import procmessage_pb2
 from biomaj_process.process_service import ProcessService


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.